### PR TITLE
Add RaydiumAmmTransactionEvents Field：blockTime

### DIFF
--- a/raydium_amm/proto/raydium_amm.proto
+++ b/raydium_amm/proto/raydium_amm.proto
@@ -9,6 +9,7 @@ message RaydiumAmmBlockEvents {
 message RaydiumAmmTransactionEvents {
     string signature = 1;
     repeated RaydiumAmmEvent events = 2;
+    uint64 blockTime = 3;
 }
 
 message RaydiumAmmEvent {

--- a/raydium_amm/proto/raydium_amm.proto
+++ b/raydium_amm/proto/raydium_amm.proto
@@ -9,7 +9,8 @@ message RaydiumAmmBlockEvents {
 message RaydiumAmmTransactionEvents {
     string signature = 1;
     repeated RaydiumAmmEvent events = 2;
-    uint64 blockTime = 3;
+    string block_time = 3;
+    string transaction_index = 4;
 }
 
 message RaydiumAmmEvent {

--- a/raydium_amm/src/lib.rs
+++ b/raydium_amm/src/lib.rs
@@ -29,12 +29,14 @@ fn raydium_amm_events(block: Block) -> Result<RaydiumAmmBlockEvents, Error> {
 
 pub fn parse_block(block: &Block) -> Vec<RaydiumAmmTransactionEvents> {
     let mut block_events: Vec<RaydiumAmmTransactionEvents> = Vec::new();
+    let timestamp = block.block_time.as_ref().unwrap().timestamp;
     for transaction in block.transactions.iter() {
         if let Ok(events) = parse_transaction(transaction) {
             if !events.is_empty() {
                 block_events.push(RaydiumAmmTransactionEvents {
                     signature: utils::transaction::get_signature(&transaction),
                     events,
+                    block_time: timestamp,
                 });
             }
         }

--- a/raydium_amm/src/lib.rs
+++ b/raydium_amm/src/lib.rs
@@ -30,13 +30,14 @@ fn raydium_amm_events(block: Block) -> Result<RaydiumAmmBlockEvents, Error> {
 pub fn parse_block(block: &Block) -> Vec<RaydiumAmmTransactionEvents> {
     let mut block_events: Vec<RaydiumAmmTransactionEvents> = Vec::new();
     let timestamp = block.block_time.as_ref().unwrap().timestamp;
-    for transaction in block.transactions.iter() {
+    for (i, transaction) in block.transactions.iter().enumerate() {
         if let Ok(events) = parse_transaction(transaction) {
             if !events.is_empty() {
                 block_events.push(RaydiumAmmTransactionEvents {
                     signature: utils::transaction::get_signature(&transaction),
                     events,
-                    block_time: timestamp,
+                    block_time: timestamp.to_string(),
+                    transaction_index: i.to_string(),
                 });
             }
         }

--- a/raydium_amm/src/pb/raydium.rs
+++ b/raydium_amm/src/pb/raydium.rs
@@ -10,7 +10,9 @@ pub struct RaydiumBlockEvents {
 pub struct RaydiumTransactionEvents {
     #[prost(string, tag="1")]
     pub signature: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="2")]
+    #[prost(int64, tag="2")]
+    pub block_time: i64,
+    #[prost(message, repeated, tag="3")]
     pub events: ::prost::alloc::vec::Vec<RaydiumEvent>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/raydium_amm/src/pb/raydium_amm.rs
+++ b/raydium_amm/src/pb/raydium_amm.rs
@@ -12,6 +12,8 @@ pub struct RaydiumAmmTransactionEvents {
     pub signature: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="2")]
     pub events: ::prost::alloc::vec::Vec<RaydiumAmmEvent>,
+    #[prost(int64, tag="3")]
+    pub block_time: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/raydium_amm/src/pb/raydium_amm.rs
+++ b/raydium_amm/src/pb/raydium_amm.rs
@@ -12,8 +12,10 @@ pub struct RaydiumAmmTransactionEvents {
     pub signature: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="2")]
     pub events: ::prost::alloc::vec::Vec<RaydiumAmmEvent>,
-    #[prost(int64, tag="3")]
-    pub block_time: i64,
+    #[prost(string, tag="3")]
+    pub block_time: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub transaction_index: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/raydium_amm/substreams.yaml
+++ b/raydium_amm/substreams.yaml
@@ -1,9 +1,9 @@
 specVersion: v0.1.0
 package:
-  name: 'raydium_amm_events'
-  version: v0.1.7
+  name: 'raydium_amm_events_with_time'
+  version: v0.2.1
   description: Raydium AMM events substream
-  url: https://github.com/0xpapercut/solana-substreams
+  url: https://github.com/0xRad7/solana-substreams
   image: ./raydium.png
 
 imports:


### PR DESCRIPTION
Hi 0xpcut,

# Requirement
    
- When i use this package, i found transaction cant get block time, so i add a field, and already test it.
     
# Test Command:
        
 `substreams run substreams.yaml raydium_amm_events -e mainnet.sol.streamingfast.io:443 -s 322802763 -t +1`

# Data Result:
```
{
  "signature": "2GhCsZGkey32vrKhxNppNbjLjC4QrjSFnkx9NTtT17rgjsuFfPNgXEh8LXejnA6aF5ztZJkwMtjpXywvFb2A7roW",
  "events": [
    {
      "swap": {
        "amm": "37ZW5PuLNyMUkngYyiFHNzm9aKcgQRNpCQPf7xvjpMVo",
        "user": "BTmzjuA4SdwwjZcv45HgFP5jBLAFmUyPJQE5CHffLvhY",
        "mintIn": "So11111111111111111111111111111111111111112",
        "mintOut": "GmjKyEhZRsMayY4N1FgycAaBuCcL3LRFczvGe8gEEVf1",
        "amountIn": "42964233",
        "amountOut": "72664581312",
        "direction": "pc",
        "poolPcAmount": "168058166405893",
        "poolCoinAmount": "99076119620",
        "pcMint": "GmjKyEhZRsMayY4N1FgycAaBuCcL3LRFczvGe8gEEVf1",
        "coinMint": "So11111111111111111111111111111111111111112",
        "userPreBalanceOut": "0"
      }
    }
  ],
  "blockTime": "1740409643"
}
```

- Hope you can release as soon as possible，because i cant publish package now. Thank for your time.
    


